### PR TITLE
Put a proper author line in for copyright purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url",
     "parser"
   ],
-  "author": "",
+  "author": "TJ Holowaychuk",
   "license": "MIT",
   "devDependencies": {
     "better-assert": "~1.0.0",


### PR DESCRIPTION
It's great that the project has the MIT license, but putting in place a copyright statement allows us to know who is putting that license on it.
