### PR TITLE
fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/visionmedia/node-github-url-from-git"
+    "url": "https://github.com/visionmedia/node-github-url-from-git.git"
   },
   "keywords": [
     "github",


### PR DESCRIPTION
The repository.url property was incorrect, which causes this warning during installs `npm WARN package.json github-url-from-git No repository field`

This will also fix the repository link on its npm page: https://www.npmjs.org/package/github-url-from-git
