### PR TITLE
Fixing edge-cases in GIT URL parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,21 @@ describe('parse(url)', function(){
     assert(null == parse(url));
   })
 
+  it('should parse git@github.com:bcoe/thumbd.git', function() {
+    var url = 'git@github.com:bcoe/thumbd.git';
+    parse(url).should.eql('https://github.com/bcoe/thumbd');
+  })
+
+  it('should parse git@github.com:bcoe/thumbd.git#2.7.0', function() {
+    var url = 'git@github.com:bcoe/thumbd.git#2.7.0';
+    parse(url).should.eql('https://github.com/bcoe/thumbd');
+  })
+
+  it('should parse https://EastCloud@github.com/EastCloud/node-websockets.git', function() {
+    var url = 'https://EastCloud@github.com/EastCloud/node-websockets.git';
+    parse(url).should.eql('https://github.com/EastCloud/node-websockets');
+  })
+
   // gist urls.
 
   it('should parse git@gist urls', function() {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 // https://github.com/bcoe/foo.
 function githubUrlFromGit(url, opts){
   try {
-    var m = re(opts).exec(url.replace(/\.git$/, ''));
+    var m = re(opts).exec(url.replace(/\.git(#.*)?$/, ''));
     var host = m[1];
     var path = m[2];
     return 'https://' + host + '/' + path;

--- a/test.js
+++ b/test.js
@@ -27,6 +27,21 @@ describe('parse(url)', function(){
     assert(null == parse(url));
   })
 
+  it('should parse git@github.com:bcoe/thumbd.git', function() {
+    var url = 'git@github.com:bcoe/thumbd.git';
+    parse(url).should.eql('https://github.com/bcoe/thumbd');
+  })
+
+  it('should parse git@github.com:bcoe/thumbd.git#2.7.0', function() {
+    var url = 'git@github.com:bcoe/thumbd.git#2.7.0';
+    parse(url).should.eql('https://github.com/bcoe/thumbd');
+  })
+
+  it('should parse https://EastCloud@github.com/EastCloud/node-websockets.git', function() {
+    var url = 'https://EastCloud@github.com/EastCloud/node-websockets.git';
+    parse(url).should.eql('https://github.com/EastCloud/node-websockets');
+  })
+
   // gist urls.
 
   it('should parse git@gist urls', function() {


### PR DESCRIPTION
- added test case for: https://github.com/visionmedia/node-github-url-from-git/issues/3
- we now handle tags/version: see https://github.com/visionmedia/node-github-url-from-git/issues/9
