### PR TITLE
Support paths starting with / in git@ urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function re(opts) {
   return new RegExp(
     /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?/.source +
     '(' + baseUrls.join('|') + ')' +
-    /[:\/]([^\/]+\/[^\/]+?|[0-9]+)$/.source
+    /[:\/]\/?([^\/]+\/[^\/]+?|[0-9]+)$/.source
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function re(opts) {
   return new RegExp(
     /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?/.source +
     '(' + baseUrls.join('|') + ')' +
-    /[:\/]\/?([^\/]+\/[^\/]+?|[0-9]+)$/.source
+    /(?::\/?|\/)([^\/]+\/[^\/]+?|[0-9]+)$/.source
   );
 }
 

--- a/test.js
+++ b/test.js
@@ -32,6 +32,11 @@ describe('parse(url)', function(){
     parse(url).should.eql('https://github.com/bcoe/thumbd');
   })
 
+  it('should parse git@github.com:/bcoe/thumbd.git', function() {
+    var url = 'git@github.com:/bcoe/thumbd.git';
+    parse(url).should.eql('https://github.com/bcoe/thumbd');
+  });
+
   it('should parse git@github.com:bcoe/thumbd.git#2.7.0', function() {
     var url = 'git@github.com:bcoe/thumbd.git#2.7.0';
     parse(url).should.eql('https://github.com/bcoe/thumbd');
@@ -84,7 +89,7 @@ describe('parse(url)', function(){
 describe('re', function() {
   it('should expose GitHub url parsing regex', function() {
     parse.re.source.should.equal(
-      /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?(gist.github.com|github.com)[:\/]([^\/]+\/[^\/]+?|[0-9]+)$/.source
+      /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?(gist.github.com|github.com)[:\/]\/?([^\/]+\/[^\/]+?|[0-9]+)$/.source
     )
   });
 })

--- a/test.js
+++ b/test.js
@@ -89,7 +89,7 @@ describe('parse(url)', function(){
 describe('re', function() {
   it('should expose GitHub url parsing regex', function() {
     parse.re.source.should.equal(
-      /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?(gist.github.com|github.com)[:\/]\/?([^\/]+\/[^\/]+?|[0-9]+)$/.source
+      /^(?:https?:\/\/|git:\/\/|git\+ssh:\/\/|git\+https:\/\/)?(?:[^@]+@)?(gist.github.com|github.com)(?::\/?|\/)([^\/]+\/[^\/]+?|[0-9]+)$/.source
     )
   });
 })


### PR DESCRIPTION
Adds support for git@ urls with a slash at the start of the path e.g. `git@github.com:/user/repo`
