### PR TITLE
feat: add typescript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+declare namespace githubUrlFromGit {
+  interface githubUrlFromGitOptions {
+    /**
+     * additional URLs that should be treated as GitHub repos
+     */
+    extraBaseUrls?: string[];
+  }
+
+  /**
+   * Create a regular expression to parse GitHub URLs
+   *
+   * @param opts options for regular expression generator
+   */
+  function re(opts?: githubUrlFromGitOptions): RegExp;
+}
+
+/**
+ * Normalize Git URLs into GitHub URLs
+ *
+ * @param url Git URL to process
+ * @param opts options for URL parser
+ * @returns GitHub URL
+ */
+declare function githubUrlFromGit(
+  url: string,
+  opts?: githubUrlFromGit.githubUrlFromGitOptions
+): string;
+
+export = githubUrlFromGit;


### PR DESCRIPTION
These are already available as `@types/github-url-from-git`, but it's preferred to provide typescript definitions from the package itself

See DefinitelyTyped/DefinitelyTyped#38576